### PR TITLE
Make it easier to verify the Sapling parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,45 @@
 [[package]]
+name = "argon2rs"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "autocfg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "backtrace"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -56,6 +92,16 @@ version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cc"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +117,36 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dirs"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_users 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -128,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.40"
+version = "0.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -141,7 +217,7 @@ name = "num_cpus"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -181,14 +257,51 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "proc-macro2"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_users"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sapling-crypto"
@@ -209,6 +322,7 @@ version = "0.2.0"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "phase2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -217,8 +331,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.15.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typenum"
 version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -241,16 +386,25 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
+"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
+"checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum bellman 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eae372472c7ea8f7c8fc6a62f7d5535db8302de7f1aafda2e13a97c4830d3bcf"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum blake2-rfc 0.2.18 (git+https://github.com/gtank/blake2-rfc?rev=7a5b5fc99ae483a0043db7547fb79a6fa44b88a9)" = "<none>"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74c0b906e9446b0a2e4f760cdb3fa4b2c48cdc6db8766a845c54b6ff063fd2e9"
+"checksum cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)" = "4390a3b5f4f6bce9c1d0c00128379df433e53777fdd30e92f16a529332baec4e"
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"
 "checksum digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "00a49051fef47a72c9623101b19bd71924a45cca838826caae3eaa4d00772603"
+"checksum dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a"
+"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
@@ -258,16 +412,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4da5f0e01bd8a71a224a4eedecaacfcabda388dbb7a80faf04d3514287572d95"
 "checksum hex-literal-impl 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1d340b6514f232f6db1bd16db65302a5278a04fef9ce867cb932e7e5fa21130a"
-"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ceda21136251c6d5a422d3d798d8ac22515a6e8d3521bb60c59a8349d36d0d57"
 "checksum phase2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "606ceb505d6e61f0dfbbc1cd1df498c3e58ad17001f06cb874c3324dd5700e77"
 "checksum proc-macro-hack 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ba8d4f9257b85eb6cdf13f055cea3190520aab1409ca2ab43493ea4820c25f0"
 "checksum proc-macro-hack-impl 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5cb6f960ad471404618e9817c0e5d10b1ae74cfdf01fab89ea0641fe7fb2892"
+"checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
+"checksum redox_users 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "214a97e49be64fd2c86f568dd0cb2c757d2cc53de95b273b6ad0a1c908482f26"
+"checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum sapling-crypto 0.0.1 (git+https://github.com/zcash-hackworks/sapling-crypto?rev=eb409fa3cf8df215ae8d35f5e385751a0c5ffb85)" = "<none>"
+"checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
+"checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
+"checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ name = "verify_transform"
 name = "split_params"
 
 [dependencies]
+dirs = { version = "1", optional = true }
 phase2 = "0.2.1"
 pairing = "0.14"
 rand = "0.4"
@@ -44,6 +45,6 @@ version = "0.1"
 optional = true
 
 [features]
-verification = ["sapling-crypto"]
+verification = ["dirs", "sapling-crypto"]
 u128-support = ["pairing/u128-support"]
 beacon = ["byteorder", "hex-literal"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,25 @@
 
 This code can be used to participate and verify the Sapling network upgrade MPC.
 
-## What do I do?
+## How do I verify the Sapling parameters?
+
+1. Download these three files from the [Powers of Tau ceremony](https://lists.zfnd.org/pipermail/zapps-wg/2018/000362.html) and place them in your current directory:
+   * `phase1radix2m13`
+   * `phase1radix2m17`
+   * `phase1radix2m21`
+
+2. Ensure you have downloaded the Sapling parameters. If you have Zcash installed on Debian or Ubuntu, you can run `zcash-fetch-params` to obtain them; otherwise, download the Zcash source code, and then run `./zcutil/fetch-params.sh` to obtain them.
+
+3. Run the following command:
+   ```sh
+   cargo run --release --bin verify --features="verification"
+   ```
+
+## How do I participate?
+
+The Sapling ceremony is complete!
+
+### How did participation work?
 
 Contact **mpc@z.cash** to schedule a time to participate. You'll need the latest (stable) [Rust compiler](https://www.rust-lang.org/) to participate using this code.
 

--- a/src/bin/beacon.rs
+++ b/src/bin/beacon.rs
@@ -1,22 +1,22 @@
-extern crate phase2;
-extern crate pairing;
-extern crate rand;
 extern crate blake2_rfc;
 extern crate byteorder;
+extern crate pairing;
+extern crate phase2;
+extern crate rand;
 
 #[macro_use]
 extern crate hex_literal;
 
-use std::fs::File;
-use std::io::{BufWriter, BufReader};
 use blake2_rfc::blake2b::Blake2b;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
 
 fn main() {
     let current_params = File::open("params").expect("couldn't open `./params`");
-    let mut current_params = BufReader::with_capacity(1024*1024, current_params);
+    let mut current_params = BufReader::with_capacity(1024 * 1024, current_params);
 
     let new_params = File::create("new_params").expect("couldn't create `./new_params`");
-    let mut new_params = BufWriter::with_capacity(1024*1024, new_params);
+    let mut new_params = BufWriter::with_capacity(1024 * 1024, new_params);
 
     let mut sapling_spend = phase2::MPCParameters::read(&mut current_params, false)
         .expect("couldn't deserialize Sapling Spend params");
@@ -29,12 +29,13 @@ fn main() {
 
     // Create an RNG based on the outcome of the random beacon
     let rng = &mut {
-        use byteorder::{ReadBytesExt, BigEndian};
-        use rand::{SeedableRng};
+        use byteorder::{BigEndian, ReadBytesExt};
         use rand::chacha::ChaChaRng;
+        use rand::SeedableRng;
 
         // Place beacon value here (2^42 SHA256 hash of Bitcoin block hash #534861)
-        let beacon_value: [u8; 32] = hex!("2bf41a959668e5b9b688e58d613b3dcc99ee159a880cf764ec67e6488d8b8af3");
+        let beacon_value: [u8; 32] =
+            hex!("2bf41a959668e5b9b688e58d613b3dcc99ee159a880cf764ec67e6488d8b8af3");
 
         print!("Final result of beacon: ");
         for b in beacon_value.iter() {
@@ -46,7 +47,9 @@ fn main() {
 
         let mut seed = [0u32; 8];
         for i in 0..8 {
-            seed[i] = digest.read_u32::<BigEndian>().expect("digest is large enough for this to work");
+            seed[i] = digest
+                .read_u32::<BigEndian>()
+                .expect("digest is large enough for this to work");
         }
 
         ChaChaRng::from_seed(&seed)
@@ -56,9 +59,15 @@ fn main() {
     let h2 = sapling_output.contribute(rng);
     let h3 = sprout_joinsplit.contribute(rng);
 
-    sapling_spend.write(&mut new_params).expect("couldn't write new Sapling Spend params");
-    sapling_output.write(&mut new_params).expect("couldn't write new Sapling Spend params");
-    sprout_joinsplit.write(&mut new_params).expect("couldn't write new Sapling Spend params");
+    sapling_spend
+        .write(&mut new_params)
+        .expect("couldn't write new Sapling Spend params");
+    sapling_output
+        .write(&mut new_params)
+        .expect("couldn't write new Sapling Spend params");
+    sprout_joinsplit
+        .write(&mut new_params)
+        .expect("couldn't write new Sapling Spend params");
 
     let mut h = Blake2b::new(64);
     h.update(&h1);
@@ -66,9 +75,11 @@ fn main() {
     h.update(&h3);
     let h = h.finalize();
 
-    print!("Done!\n\n\
-              Your contribution has been written to `./new_params`\n\n\
-              The contribution you made is bound to the following hash:\n");
+    print!(
+        "Done!\n\n\
+         Your contribution has been written to `./new_params`\n\n\
+         The contribution you made is bound to the following hash:\n"
+    );
 
     for line in h.as_ref().chunks(16) {
         print!("\t");

--- a/src/bin/compute.rs
+++ b/src/bin/compute.rs
@@ -1,18 +1,18 @@
-extern crate phase2;
-extern crate pairing;
-extern crate rand;
 extern crate blake2_rfc;
+extern crate pairing;
+extern crate phase2;
+extern crate rand;
 
-use std::fs::File;
-use std::io::{BufWriter, BufReader};
 use blake2_rfc::blake2b::Blake2b;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
 
 fn main() {
     let current_params = File::open("params").expect("couldn't open `./params`");
-    let mut current_params = BufReader::with_capacity(1024*1024, current_params);
+    let mut current_params = BufReader::with_capacity(1024 * 1024, current_params);
 
     let new_params = File::create("new_params").expect("couldn't create `./new_params`");
-    let mut new_params = BufWriter::with_capacity(1024*1024, new_params);
+    let mut new_params = BufWriter::with_capacity(1024 * 1024, new_params);
 
     let mut sapling_spend = phase2::MPCParameters::read(&mut current_params, false)
         .expect("couldn't deserialize Sapling Spend params");
@@ -29,9 +29,15 @@ fn main() {
     let h2 = sapling_output.contribute(rng);
     let h3 = sprout_joinsplit.contribute(rng);
 
-    sapling_spend.write(&mut new_params).expect("couldn't write new Sapling Spend params");
-    sapling_output.write(&mut new_params).expect("couldn't write new Sapling Spend params");
-    sprout_joinsplit.write(&mut new_params).expect("couldn't write new Sapling Spend params");
+    sapling_spend
+        .write(&mut new_params)
+        .expect("couldn't write new Sapling Spend params");
+    sapling_output
+        .write(&mut new_params)
+        .expect("couldn't write new Sapling Spend params");
+    sprout_joinsplit
+        .write(&mut new_params)
+        .expect("couldn't write new Sapling Spend params");
 
     let mut h = Blake2b::new(64);
     h.update(&h1);
@@ -39,9 +45,11 @@ fn main() {
     h.update(&h3);
     let h = h.finalize();
 
-    print!("Done!\n\n\
-              Your contribution has been written to `./new_params`\n\n\
-              The contribution you made is bound to the following hash:\n");
+    print!(
+        "Done!\n\n\
+         Your contribution has been written to `./new_params`\n\n\
+         The contribution you made is bound to the following hash:\n"
+    );
 
     for line in h.as_ref().chunks(16) {
         print!("\t");

--- a/src/bin/new.rs
+++ b/src/bin/new.rs
@@ -1,6 +1,6 @@
+extern crate pairing;
 extern crate phase2;
 extern crate sapling_crypto;
-extern crate pairing;
 
 use std::fs::File;
 use std::io::BufWriter;
@@ -20,8 +20,11 @@ fn main() {
         commitment_randomness: None,
         ar: None,
         auth_path: vec![None; 32], // Tree depth is 32 for sapling
-        anchor: None
-    }).unwrap().write(&mut params).unwrap();
+        anchor: None,
+    })
+    .unwrap()
+    .write(&mut params)
+    .unwrap();
 
     // Sapling output circuit
     phase2::MPCParameters::new(sapling_crypto::circuit::sapling::Output {
@@ -29,8 +32,11 @@ fn main() {
         value_commitment: None,
         payment_address: None,
         commitment_randomness: None,
-        esk: None
-    }).unwrap().write(&mut params).unwrap();
+        esk: None,
+    })
+    .unwrap()
+    .write(&mut params)
+    .unwrap();
 
     // Sprout joinsplit circuit
     phase2::MPCParameters::new(sapling_crypto::circuit::sprout::JoinSplit {
@@ -38,28 +44,37 @@ fn main() {
         vpub_new: None,
         h_sig: None,
         phi: None,
-        inputs: vec![sapling_crypto::circuit::sprout::JSInput {
-            value: None,
-            a_sk: None,
-            rho: None,
-            r: None,
-            auth_path: [None; 29] // Depth is 29 for Sprout
-        }, sapling_crypto::circuit::sprout::JSInput {
-            value: None,
-            a_sk: None,
-            rho: None,
-            r: None,
-            auth_path: [None; 29] // Depth is 29 for Sprout
-        }],
-        outputs: vec![sapling_crypto::circuit::sprout::JSOutput {
-            value: None,
-            a_pk: None,
-            r: None
-        }, sapling_crypto::circuit::sprout::JSOutput {
-            value: None,
-            a_pk: None,
-            r: None
-        }],
+        inputs: vec![
+            sapling_crypto::circuit::sprout::JSInput {
+                value: None,
+                a_sk: None,
+                rho: None,
+                r: None,
+                auth_path: [None; 29], // Depth is 29 for Sprout
+            },
+            sapling_crypto::circuit::sprout::JSInput {
+                value: None,
+                a_sk: None,
+                rho: None,
+                r: None,
+                auth_path: [None; 29], // Depth is 29 for Sprout
+            },
+        ],
+        outputs: vec![
+            sapling_crypto::circuit::sprout::JSOutput {
+                value: None,
+                a_pk: None,
+                r: None,
+            },
+            sapling_crypto::circuit::sprout::JSOutput {
+                value: None,
+                a_pk: None,
+                r: None,
+            },
+        ],
         rt: None,
-    }).unwrap().write(&mut params).unwrap();
+    })
+    .unwrap()
+    .write(&mut params)
+    .unwrap();
 }

--- a/src/bin/split_params.rs
+++ b/src/bin/split_params.rs
@@ -1,16 +1,16 @@
 //! This binary just splits the parameters up into separate files.
 
-extern crate phase2;
-extern crate pairing;
-extern crate rand;
 extern crate blake2_rfc;
+extern crate pairing;
+extern crate phase2;
+extern crate rand;
 
 use std::fs::File;
-use std::io::{BufWriter, BufReader};
+use std::io::{BufReader, BufWriter};
 
 fn main() {
     let current_params = File::open("params").expect("couldn't open `./params`");
-    let mut current_params = BufReader::with_capacity(1024*1024, current_params);
+    let mut current_params = BufReader::with_capacity(1024 * 1024, current_params);
 
     let sapling_spend = phase2::MPCParameters::read(&mut current_params, false)
         .expect("couldn't deserialize Sapling Spend params");
@@ -22,23 +22,29 @@ fn main() {
         .expect("couldn't deserialize Sprout JoinSplit params");
 
     {
-        let f = File::create("sapling-spend.params").expect("couldn't create `./sapling-spend.params`");
-        let mut f = BufWriter::with_capacity(1024*1024, f);
-        sapling_spend.write(&mut f)
+        let f =
+            File::create("sapling-spend.params").expect("couldn't create `./sapling-spend.params`");
+        let mut f = BufWriter::with_capacity(1024 * 1024, f);
+        sapling_spend
+            .write(&mut f)
             .expect("couldn't write new Sapling Spend params");
     }
 
     {
-        let f = File::create("sapling-output.params").expect("couldn't create `./sapling-output.params`");
-        let mut f = BufWriter::with_capacity(1024*1024, f);
-        sapling_output.write(&mut f)
+        let f = File::create("sapling-output.params")
+            .expect("couldn't create `./sapling-output.params`");
+        let mut f = BufWriter::with_capacity(1024 * 1024, f);
+        sapling_output
+            .write(&mut f)
             .expect("couldn't write new Sapling Output params");
     }
 
     {
-        let f = File::create("sprout-groth16.params").expect("couldn't create `./sapling-groth16.params`");
-        let mut f = BufWriter::with_capacity(1024*1024, f);
-        sprout_joinsplit.write(&mut f)
+        let f = File::create("sprout-groth16.params")
+            .expect("couldn't create `./sapling-groth16.params`");
+        let mut f = BufWriter::with_capacity(1024 * 1024, f);
+        sprout_joinsplit
+            .write(&mut f)
             .expect("couldn't write new Sprout JoinSplit params");
     }
 }

--- a/src/bin/verify.rs
+++ b/src/bin/verify.rs
@@ -1,11 +1,11 @@
+extern crate blake2_rfc;
+extern crate pairing;
 extern crate phase2;
 extern crate sapling_crypto;
-extern crate pairing;
-extern crate blake2_rfc;
 
+use blake2_rfc::blake2b::Blake2b;
 use std::fs::File;
 use std::io::BufReader;
-use blake2_rfc::blake2b::Blake2b;
 
 fn main() {
     let jubjub_params = sapling_crypto::jubjub::JubjubBls12::new();
@@ -22,56 +22,69 @@ fn main() {
     let sprout_joinsplit = phase2::MPCParameters::read(&mut params, true)
         .expect("couldn't deserialize Sprout JoinSplit params");
 
-    let sapling_spend_contributions = sapling_spend.verify(sapling_crypto::circuit::sapling::Spend {
-        params: &jubjub_params,
-        value_commitment: None,
-        proof_generation_key: None,
-        payment_address: None,
-        commitment_randomness: None,
-        ar: None,
-        auth_path: vec![None; 32], // Tree depth is 32 for sapling
-        anchor: None
-    }).expect("parameters are invalid");
+    let sapling_spend_contributions = sapling_spend
+        .verify(sapling_crypto::circuit::sapling::Spend {
+            params: &jubjub_params,
+            value_commitment: None,
+            proof_generation_key: None,
+            payment_address: None,
+            commitment_randomness: None,
+            ar: None,
+            auth_path: vec![None; 32], // Tree depth is 32 for sapling
+            anchor: None,
+        })
+        .expect("parameters are invalid");
 
-    let sapling_output_contributions = sapling_output.verify(sapling_crypto::circuit::sapling::Output {
-        params: &jubjub_params,
-        value_commitment: None,
-        payment_address: None,
-        commitment_randomness: None,
-        esk: None
-    }).expect("parameters are invalid");
+    let sapling_output_contributions = sapling_output
+        .verify(sapling_crypto::circuit::sapling::Output {
+            params: &jubjub_params,
+            value_commitment: None,
+            payment_address: None,
+            commitment_randomness: None,
+            esk: None,
+        })
+        .expect("parameters are invalid");
 
-    let sprout_joinsplit_contributions = sprout_joinsplit.verify(sapling_crypto::circuit::sprout::JoinSplit {
-        vpub_old: None,
-        vpub_new: None,
-        h_sig: None,
-        phi: None,
-        inputs: vec![sapling_crypto::circuit::sprout::JSInput {
-            value: None,
-            a_sk: None,
-            rho: None,
-            r: None,
-            auth_path: [None; 29] // Depth is 29 for Sprout
-        }, sapling_crypto::circuit::sprout::JSInput {
-            value: None,
-            a_sk: None,
-            rho: None,
-            r: None,
-            auth_path: [None; 29] // Depth is 29 for Sprout
-        }],
-        outputs: vec![sapling_crypto::circuit::sprout::JSOutput {
-            value: None,
-            a_pk: None,
-            r: None
-        }, sapling_crypto::circuit::sprout::JSOutput {
-            value: None,
-            a_pk: None,
-            r: None
-        }],
-        rt: None,
-    }).expect("parameters are invalid");
+    let sprout_joinsplit_contributions = sprout_joinsplit
+        .verify(sapling_crypto::circuit::sprout::JoinSplit {
+            vpub_old: None,
+            vpub_new: None,
+            h_sig: None,
+            phi: None,
+            inputs: vec![
+                sapling_crypto::circuit::sprout::JSInput {
+                    value: None,
+                    a_sk: None,
+                    rho: None,
+                    r: None,
+                    auth_path: [None; 29], // Depth is 29 for Sprout
+                },
+                sapling_crypto::circuit::sprout::JSInput {
+                    value: None,
+                    a_sk: None,
+                    rho: None,
+                    r: None,
+                    auth_path: [None; 29], // Depth is 29 for Sprout
+                },
+            ],
+            outputs: vec![
+                sapling_crypto::circuit::sprout::JSOutput {
+                    value: None,
+                    a_pk: None,
+                    r: None,
+                },
+                sapling_crypto::circuit::sprout::JSOutput {
+                    value: None,
+                    a_pk: None,
+                    r: None,
+                },
+            ],
+            rt: None,
+        })
+        .expect("parameters are invalid");
 
-    for ((a, b), c) in sapling_spend_contributions.into_iter()
+    for ((a, b), c) in sapling_spend_contributions
+        .into_iter()
         .zip(sapling_output_contributions.into_iter())
         .zip(sprout_joinsplit_contributions)
     {

--- a/src/bin/verify.rs
+++ b/src/bin/verify.rs
@@ -1,16 +1,17 @@
 extern crate blake2_rfc;
+extern crate dirs;
 extern crate pairing;
 extern crate phase2;
 extern crate sapling_crypto;
 
 use blake2_rfc::blake2b::Blake2b;
+use phase2::MPCParameters;
 use std::fs::File;
-use std::io::BufReader;
+use std::io::{self, BufReader};
+use std::path::PathBuf;
 
-fn main() {
-    let jubjub_params = sapling_crypto::jubjub::JubjubBls12::new();
-
-    let params = File::open("params").unwrap();
+fn load_combined_params(params: PathBuf) -> (MPCParameters, MPCParameters, MPCParameters) {
+    let params = File::open(params).expect("couldn't open combined params file");
     let mut params = BufReader::with_capacity(1024 * 1024, params);
 
     let sapling_spend = phase2::MPCParameters::read(&mut params, true)
@@ -21,6 +22,61 @@ fn main() {
 
     let sprout_joinsplit = phase2::MPCParameters::read(&mut params, true)
         .expect("couldn't deserialize Sprout JoinSplit params");
+
+    (sapling_spend, sapling_output, sprout_joinsplit)
+}
+
+fn load_one(params: PathBuf) -> io::Result<MPCParameters> {
+    println!("Loading {}", params.to_string_lossy());
+    let params = File::open(params)?;
+    let mut params = BufReader::with_capacity(1024 * 1024, params);
+    phase2::MPCParameters::read(&mut params, true)
+}
+
+fn load_individual_params(
+    params_dir: &PathBuf,
+) -> io::Result<(MPCParameters, MPCParameters, MPCParameters)> {
+    let sapling_spend = load_one(params_dir.join("sapling-spend.params"))?;
+    let sapling_output = load_one(params_dir.join("sapling-output.params"))?;
+    let sprout_groth16 = load_one(params_dir.join("sprout-groth16.params"))?;
+    Ok((sapling_spend, sapling_output, sprout_groth16))
+}
+
+fn main() {
+    let jubjub_params = sapling_crypto::jubjub::JubjubBls12::new();
+
+    let combined_params = PathBuf::from("params");
+    let unix_params_dir = dirs::home_dir().map(|path| path.join(".zcash-params"));
+    let win_osx_params_dir = dirs::data_dir().map(|path| path.join("ZcashParams"));
+    let (sapling_spend, sapling_output, sprout_joinsplit) = if combined_params.exists() {
+        load_combined_params(combined_params)
+    } else {
+        match (unix_params_dir, win_osx_params_dir) {
+            (Some(ref params_dir), _) if params_dir.exists() => {
+                match load_individual_params(params_dir) {
+                    Ok(params) => params,
+                    Err(e) => {
+                        println!("Failed to load parameters: {}", e);
+                        return;
+                    }
+                }
+            }
+            (_, Some(ref params_dir)) if params_dir.exists() => {
+                match load_individual_params(params_dir) {
+                    Ok(params) => params,
+                    Err(e) => {
+                        println!("Failed to load parameters: {}", e);
+                        return;
+                    }
+                }
+            }
+            _ => {
+                println!("Cannot locate the Zcash parameters.");
+                println!("Please run zcash-fetch-params or fetch-params.sh to download the parameters, and then re-run this tool.");
+                return;
+            }
+        }
+    };
 
     let sapling_spend_contributions = sapling_spend
         .verify(sapling_crypto::circuit::sapling::Spend {

--- a/src/bin/verify.rs
+++ b/src/bin/verify.rs
@@ -78,6 +78,7 @@ fn main() {
         }
     };
 
+    println!("Verifying Sapling spend parameters...");
     let sapling_spend_contributions = sapling_spend
         .verify(sapling_crypto::circuit::sapling::Spend {
             params: &jubjub_params,
@@ -91,6 +92,7 @@ fn main() {
         })
         .expect("parameters are invalid");
 
+    println!("Verifying Sapling output parameters...");
     let sapling_output_contributions = sapling_output
         .verify(sapling_crypto::circuit::sapling::Output {
             params: &jubjub_params,
@@ -101,6 +103,7 @@ fn main() {
         })
         .expect("parameters are invalid");
 
+    println!("Verifying Sprout parameters...");
     let sprout_joinsplit_contributions = sprout_joinsplit
         .verify(sapling_crypto::circuit::sprout::JoinSplit {
             vpub_old: None,
@@ -139,6 +142,7 @@ fn main() {
         })
         .expect("parameters are invalid");
 
+    println!("Parameters verified! Here is the list of contribution hashes:");
     for ((a, b), c) in sapling_spend_contributions
         .into_iter()
         .zip(sapling_output_contributions.into_iter())

--- a/src/bin/verify_transform.rs
+++ b/src/bin/verify_transform.rs
@@ -1,10 +1,10 @@
-extern crate phase2;
-extern crate pairing;
 extern crate blake2_rfc;
+extern crate pairing;
+extern crate phase2;
 
+use blake2_rfc::blake2b::Blake2b;
 use std::fs::File;
 use std::io::BufReader;
-use blake2_rfc::blake2b::Blake2b;
 
 fn main() {
     let params = File::open("params").unwrap();
@@ -33,17 +33,17 @@ fn main() {
 
     let h1 = match phase2::verify_contribution(&sapling_spend, &new_sapling_spend) {
         Ok(hash) => hash,
-        Err(_) => panic!("invalid transformation!")
+        Err(_) => panic!("invalid transformation!"),
     };
 
     let h2 = match phase2::verify_contribution(&sapling_output, &new_sapling_output) {
         Ok(hash) => hash,
-        Err(_) => panic!("invalid transformation!")
+        Err(_) => panic!("invalid transformation!"),
     };
 
     let h3 = match phase2::verify_contribution(&sprout_joinsplit, &new_sprout_joinsplit) {
         Ok(hash) => hash,
-        Err(_) => panic!("invalid transformation!")
+        Err(_) => panic!("invalid transformation!"),
     };
 
     let mut h = Blake2b::new(64);


### PR DESCRIPTION
- Sapling parameters will now be used from their default location if a `params` file is not provided in the current directory.
  - Tested on Ubuntu and Windows 10.
- High-level status updates are now printed.